### PR TITLE
Reject INSERT ... ON CONFLICT introduced in PostgreSQL 9.5.

### DIFF
--- a/ifx_fdw.c
+++ b/ifx_fdw.c
@@ -1173,6 +1173,18 @@ ifxPlanForeignModify(PlannerInfo *root,
 							   get_rel_name(rte->relid))));
 	}
 
+#if PG_VERSION_NUM >= 90500
+	/*
+	 * Don't support INSERT ... ON CONFLICT.
+	 */
+
+	if (plan->onConflictAction != ONCONFLICT_NONE)
+	{
+		ereport(ERROR, (errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
+						errmsg("INSERT with ON CONFLICT clause is not supported")));
+	}
+#endif
+
 	/*
 	 * In case we have an UPDATE or DELETE action, retrieve the foreign scan state
 	 * data belonging to the ForeignScan, initiated by the earlier scan node.


### PR DESCRIPTION
This was added in PostgreSQL commit 168d5805e4c08bed7b95d351bf097cff7c07dd65.

I added this change in oracle_fdw and thought you could use it too.

Without this, INSERT .. ON CONFLICT IGNORE might do the wrong thing and throw an error message when there is a conflict.